### PR TITLE
Adds in Kobo Collection Manager script

### DIFF
--- a/bin/koco
+++ b/bin/koco
@@ -25,7 +25,7 @@ if [ "$#" -ne 2 ]; then
 fi
 
 # Copy the SQLite file out to a temporary dir as to not write a bunch on the
-#   SD card.
+#   device's internal storage.
 if [ ! -f "$1" ]; then
 	echo >&2 "Database file not found"
 	exit 2
@@ -77,5 +77,5 @@ cat "$source_file" | jq -c '.collections | to_entries[] | {key, value: .value[]}
 	fi
 done
 
-# Copy completed DB back to the SD card.
+# Copy completed DB back to internal storage.
 cp "$temp_db" "$1"

--- a/bin/koco
+++ b/bin/koco
@@ -12,8 +12,6 @@ help() {
 	jq -n '{"collections": {"Some Collection Name": ["some/book/path.epub"]}}'
 }
 
-# TODO: Create a clean up trap to delete temp files.
-
 if [ "$#" -ne 2 ]; then
 	if [ "$1" = "-h" ]; then
 		help
@@ -39,14 +37,17 @@ EXISTS_QUERY='"SELECT 1 FROM content WHERE ContentType = 6 AND ContentId = \"fil
 CHECK_QUERY='"SELECT 1 FROM ShelfContent WHERE ShelfName = \"\(.key)\" AND ContentId = \"file:///mnt/onboard/\(.value)\";"'
 CREATE_QUERY='. + {date: $d} | "INSERT INTO ShelfContent (ShelfName, ContentId, DateModified, _IsDeleted, _IsSynced) VALUES (\"\(.key)\", \"file:///mnt/onboard/\(.value)\", \"\(.date)\", \"false\", \"false\");"'
 
-temp_db="$(mktemp)"
+temp_dir="$(mktemp -d)"
+trap 'rm -rf -- "$temp_dir"' EXIT
+
+temp_db="$temp_dir/db.sqlite"
 cp "$1" "$temp_db"
 
 # Can't read stdin multiple times, so if this is reading from stdin, dump to
 #   temp file.
 source_file="$2"
 if [ "$source_file" = "-" ]; then
-	source_file="$(mktemp)"
+	source_file="$temp_dir/collections.json"
 	cat - > "$source_file"
 fi
 

--- a/bin/koco
+++ b/bin/koco
@@ -6,9 +6,9 @@
 
 # Update to accept `-` or file from command line.
 # Probably also add an example file output or something.
-if [ "$#" -ne 1 ]; then
+if [ "$#" -ne 2 ]; then
 	echo >&2 "Usage:"
-	echo >&2 "  $0 <db file>"
+	echo >&2 "  $0 <db file> <collections-json|->"
 	exit 1
 fi
 
@@ -26,7 +26,7 @@ CREATE_QUERY='. + {date: $d} | "INSERT INTO ShelfContent (ShelfName, ContentId, 
 temp_db="$(mktemp)"
 cp "$1" "$temp_db"
 
-cat - | jq -c '.collections | to_entries[] | {key, value: .value[]}' | while read -r line; do
+cat "$2" | jq -c '.collections | to_entries[] | {key, value: .value[]}' | while read -r line; do
 	query="$(jq -r "$CHECK_QUERY" <<< "$line")"
 	if [ -z "$(sqlite3 "$temp_db" "$query")" ]; then
 		command="$(jq -r --arg "d" "$RUN_DATE" "$CREATE_QUERY" <<< "$line")"

--- a/bin/koco
+++ b/bin/koco
@@ -13,7 +13,7 @@ help() {
 }
 
 if [ "$#" -ne 2 ]; then
-	if [ "$1" = "-h" ]; then
+	if [ "$#" -eq 1 ] && [ "$1" = "-h" ]; then
 		help
 		exit
 	fi

--- a/bin/koco
+++ b/bin/koco
@@ -5,6 +5,8 @@ set -euf
 
 # cat ~/Desktop/collections.json | ~/Desktop/script.sh ~/Desktop/KoboReader.sqlite
 
+# Create a clean up trap to delete temp files.
+
 # Update to accept `-` or file from command line.
 # Probably also add an example file output or something.
 if [ "$#" -ne 2 ]; then
@@ -21,13 +23,32 @@ if [ ! -f "$1" ]; then
 fi
 
 RUN_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+CHECK_COLLECTION_QUERY='"SELECT 1 FROM Shelf WHERE Id = \"\(.value)\";"'
 CHECK_QUERY='"SELECT 1 FROM ShelfContent WHERE ShelfName = \"\(.key)\" AND ContentId = \"file:///mnt/onboard/\(.value)\";"'
 CREATE_QUERY='. + {date: $d} | "INSERT INTO ShelfContent (ShelfName, ContentId, DateModified, _IsDeleted, _IsSynced) VALUES (\"\(.key)\", \"file:///mnt/onboard/\(.value)\", \"\(.date)\", \"false\", \"false\");"'
 
 temp_db="$(mktemp)"
 cp "$1" "$temp_db"
 
-cat "$2" | jq -c '.collections | to_entries[] | {key, value: .value[]}' | while read -r line; do
+# Can't read stdin multiple times, so if this is reading from stdin, dump to
+#   temp file.
+source_file="$2"
+if [ "$source_file" = "-" ]; then
+	source_file="$(mktemp)"
+	cat - > "$source_file"
+fi
+
+# Validate that collections exist.
+cat "$source_file" | jq -c '.collections | keys | to_entries[]' | while read -r line; do
+	query="$(jq -r "$CHECK_COLLECTION_QUERY" <<< "$line")"
+	if [ -z "$(sqlite3 "$temp_db" "$query")" ]; then
+		echo >&2 "Failed to find collection: $(jq -r ".value" <<< "$line")"
+		echo >&2 "Does it exist on the device + is it spelled correctly?"
+		exit 3
+	fi
+done
+
+cat "$source_file" | jq -c '.collections | to_entries[] | {key, value: .value[]}' | while read -r line; do
 	query="$(jq -r "$CHECK_QUERY" <<< "$line")"
 	if [ -z "$(sqlite3 "$temp_db" "$query")" ]; then
 		command="$(jq -r --arg "d" "$RUN_DATE" "$CREATE_QUERY" <<< "$line")"

--- a/bin/koco
+++ b/bin/koco
@@ -12,16 +12,29 @@ if [ "$#" -ne 1 ]; then
 	exit 1
 fi
 
+# Copy the SQLite file out to a temporary dir as to not write a bunch on the
+#   SD card.
+if [ ! -f "$1" ]; then
+	echo >&2 "Database file not found"
+	exit 2
+fi
+
 RUN_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 CHECK_QUERY='"SELECT 1 FROM ShelfContent WHERE ShelfName = \"\(.key)\" AND ContentId = \"file:///mnt/onboard/\(.value)\";"'
 CREATE_QUERY='. + {date: $d} | "INSERT INTO ShelfContent (ShelfName, ContentId, DateModified, _IsDeleted, _IsSynced) VALUES (\"\(.key)\", \"file:///mnt/onboard/\(.value)\", \"\(.date)\", \"false\", \"false\");"'
 
+temp_db="$(mktemp)"
+cp "$1" "$temp_db"
+
 cat - | jq -c '.collections | to_entries[] | {key, value: .value[]}' | while read -r line; do
 	query="$(jq -r "$CHECK_QUERY" <<< "$line")"
-	if [ -z "$(sqlite3 "$1" "$query")" ]; then
+	if [ -z "$(sqlite3 "$temp_db" "$query")" ]; then
 		command="$(jq -r --arg "d" "$RUN_DATE" "$CREATE_QUERY" <<< "$line")"
-		sqlite3 "$1" "$command"
+		sqlite3 "$temp_db" "$command"
 		# Update to show collection + book path.
 		echo "Inserted $line"
 	fi
 done
+
+# Copy completed DB back to the SD card.
+cp "$temp_db" "$1"

--- a/bin/koco
+++ b/bin/koco
@@ -3,14 +3,25 @@
 # A little script to manage Sideloadmode Kobo Collections.
 set -euf
 
-# cat ~/Desktop/collections.json | ~/Desktop/script.sh ~/Desktop/KoboReader.sqlite
+help() {
+	echo "Usage:"
+	echo "  $0 -h"
+	echo "  $0 <db file> <collections-json|->"
+	echo ""
+	echo "collections-json:"
+	jq -n '{"collections": {"Some Collection Name": ["some/book/path.epub"]}}'
+}
 
-# Create a clean up trap to delete temp files.
+# TODO: Create a clean up trap to delete temp files.
 
-# Update to accept `-` or file from command line.
-# Probably also add an example file output or something.
 if [ "$#" -ne 2 ]; then
+	if [ "$1" = "-h" ]; then
+		help
+		exit
+	fi
+
 	echo >&2 "Usage:"
+	echo >&2 "  $0 -h"
 	echo >&2 "  $0 <db file> <collections-json|->"
 	exit 1
 fi

--- a/bin/koco
+++ b/bin/koco
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+#
+# A little script to manage Sideloadmode Kobo Collections.
+
+# cat ~/Desktop/collections.json | ~/Desktop/script.sh ~/Desktop/KoboReader.sqlite
+
+# Update to accept `-` or file from command line.
+# Probably also add an example file output or something.
+if [ "$#" -ne 1 ]; then
+	echo >&2 "Usage:"
+	echo >&2 "  $0 <db file>"
+	exit 1
+fi
+
+RUN_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+CHECK_QUERY='"SELECT 1 FROM ShelfContent WHERE ShelfName = \"\(.key)\" AND ContentId = \"file:///mnt/onboard/\(.value)\";"'
+CREATE_QUERY='. + {date: $d} | "INSERT INTO ShelfContent (ShelfName, ContentId, DateModified, _IsDeleted, _IsSynced) VALUES (\"\(.key)\", \"file:///mnt/onboard/\(.value)\", \"\(.date)\", \"false\", \"false\");"'
+
+cat - | jq -c '.collections | to_entries[] | {key, value: .value[]}' | while read -r line; do
+	query="$(jq -r "$CHECK_QUERY" <<< "$line")"
+	if [ -z "$(sqlite3 "$1" "$query")" ]; then
+		command="$(jq -r --arg "d" "$RUN_DATE" "$CREATE_QUERY" <<< "$line")"
+		sqlite3 "$1" "$command"
+		# Update to show collection + book path.
+		echo "Inserted $line"
+	fi
+done

--- a/bin/koco
+++ b/bin/koco
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 #
 # A little script to manage Sideloadmode Kobo Collections.
+set -euf
 
 # cat ~/Desktop/collections.json | ~/Desktop/script.sh ~/Desktop/KoboReader.sqlite
 

--- a/bin/koco
+++ b/bin/koco
@@ -61,8 +61,7 @@ cat "$source_file" | jq -c '.collections | to_entries[] | {key, value: .value[]}
 	if [ -z "$(sqlite3 "$temp_db" "$query")" ]; then
 		command="$(jq -r --arg "d" "$RUN_DATE" "$CREATE_QUERY" <<< "$line")"
 		sqlite3 "$temp_db" "$command"
-		# Update to show collection + book path.
-		echo "Inserted $line"
+		jq -r '"Inserted \"\(.value)\" into \"\(.key)\""' <<< "$line"
 	fi
 done
 

--- a/bin/koco
+++ b/bin/koco
@@ -24,6 +24,7 @@ fi
 
 RUN_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 CHECK_COLLECTION_QUERY='"SELECT 1 FROM Shelf WHERE Id = \"\(.value)\";"'
+EXISTS_QUERY='"SELECT 1 FROM content WHERE ContentType = 6 AND ContentId = \"file:///mnt/onboard/\(.value)\";"'
 CHECK_QUERY='"SELECT 1 FROM ShelfContent WHERE ShelfName = \"\(.key)\" AND ContentId = \"file:///mnt/onboard/\(.value)\";"'
 CREATE_QUERY='. + {date: $d} | "INSERT INTO ShelfContent (ShelfName, ContentId, DateModified, _IsDeleted, _IsSynced) VALUES (\"\(.key)\", \"file:///mnt/onboard/\(.value)\", \"\(.date)\", \"false\", \"false\");"'
 
@@ -49,6 +50,13 @@ cat "$source_file" | jq -c '.collections | keys | to_entries[]' | while read -r 
 done
 
 cat "$source_file" | jq -c '.collections | to_entries[] | {key, value: .value[]}' | while read -r line; do
+	query="$(jq -r "$EXISTS_QUERY" <<< "$line")"
+	if [ -z "$(sqlite3 "$temp_db" "$query")" ]; then
+		echo >&2 "Failed to find content: $(jq -r ".value" <<< "$line")"
+		echo >&2 "Does it exist on the device + is it spelled correctly?"
+		exit 4
+	fi
+
 	query="$(jq -r "$CHECK_QUERY" <<< "$line")"
 	if [ -z "$(sqlite3 "$temp_db" "$query")" ]; then
 		command="$(jq -r --arg "d" "$RUN_DATE" "$CREATE_QUERY" <<< "$line")"


### PR DESCRIPTION
Shell script that accepts in a simple JSON payload, like:

```
{
	"collections": {
		"Books I Want to Read": [
			"some book.epub",
			"some author/their book.epub"
		],
		"Books that Mom Recommends": [
			"some book.epub",
			"some other book.epub"
		]
	}
}
```

And updates a Kobo's `.kobo/KoboReader.sqlite` (assuming that's the arg you actually pass in), to update the device's collections.

Doesn't, but probably could create the collections themselves, but instead validates that they already exist. Also validates that content exists when you try to add them to collections.

I don't want to brick my Kobo, so I've kind of just been assuming anything invalid like adding to non-existent collections, or adding non-existent content to collections are bad. 

Doesn't _really_ need to be in my dotfiles by any means, but it doesn't deserve its own repo.

Probable standard flow:
```
./bin/koco /Volumes/KOBOeReader/.kobo/KoboReader.sqlite /Volumes/KOBOeReader/.collections.json 
```
And just update that collections file with the desired content and go.

---

Could potentially print out warnings/errors or something if content is in a collection that shouldn't be, or could just remove the items from the collection 🤷🏽 